### PR TITLE
Add b13/container support to the whole 2.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "license": "GPL-3.0-or-later",
   "require": {
     "php": "^8.0",
-    "typo3/cms-core": "^11.4 || ^12.4",
-    "b13/container": "1.6.* || 2.0.* || 2.1.* || 2.2.*",
+    "typo3/cms-core": "^11.5 || ^12.4",
+    "b13/container": "^1.6 || ^2.0",
     "friendsoftypo3/headless": "^3.0 || ^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
To avoid the need to update composer.json file after each b13/container minor release on the 2.x branch